### PR TITLE
Support swagger required format at the definition rather than property

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ function documentModel(Model) {
   const modelName = Model.modelName;
   const obj = {
     id: modelName,
-    properties: {}
+    properties: {},
+    required: []
   };
 
   const pathsToSchema = (parent, paths) => {
@@ -49,6 +50,10 @@ function documentModel(Model) {
         modelProp.type = adjustType(mongooseProp.instance);
         modelProp.required = mongooseProp.isRequired || false;
       }
+      if (modelProp.required) {
+        obj.required.push(mongooseProp.path);
+      }
+      delete modelProp.required;
     });
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,14 @@ function documentModel(Model) {
         modelProp.type = adjustType(mongooseProp.instance);
         modelProp.required = mongooseProp.isRequired || false;
       }
-      if (mongooseProp.description) {
-        modelProp.description = mongooseProp.description;
+      // custom mongoose options
+      if (mongooseProp.options) {
+        if (mongooseProp.options.description) {
+          modelProp.description = mongooseProp.options.description;
+        }
+      }
+      if (mongooseProp.enumValues && mongooseProp.enumValues.length) {
+        modelProp.enum = mongooseProp.enumValues;
       }
       if (modelProp.required) {
         obj.required.push(mongooseProp.path);

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ const adjustType = type => {
 
 function documentModel(Model) {
   const obj = {
+    title: Model.modelName,
     properties: {},
     required: []
   };
@@ -47,6 +48,9 @@ function documentModel(Model) {
       } else {
         modelProp.type = adjustType(mongooseProp.instance);
         modelProp.required = mongooseProp.isRequired || false;
+      }
+      if (mongooseProp.description) {
+        modelProp.description = mongooseProp.description;
       }
       if (modelProp.required) {
         obj.required.push(mongooseProp.path);

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,7 @@ const adjustType = type => {
 };
 
 function documentModel(Model) {
-  const modelName = Model.modelName;
   const obj = {
-    id: modelName,
     properties: {},
     required: []
   };

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -90,7 +90,8 @@ describe(path.basename(__filename).replace('.test.js', ''), () => {
       expect(props.comments.items.properties).toExist();
       expect(props.comments.items.properties.body).toExist();
       expect(props.comments.items.properties.date).toExist();
-      expect(props.comments.items.properties.body).toEqual({type: 'string', required: false});
+      expect(props.comments.items.properties.body).toEqual({type: 'string'});
+      expect(result.required).toEqual(['hidden']);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
     "email": "b.lugavere@gmail.com",
     "url": "http://benlugavere.com"
   },
-  "files": [
-    "dist"
-  ],
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "keywords": [
     "swagger",
     "openapi",

--- a/test/index.js
+++ b/test/index.js
@@ -19,4 +19,24 @@ describe('mongoose-to-swagger', function () {
       expect(swaggerSchema.properties).toExist();
     });
   });
+  describe('when there are required schema props', () => {
+    it('should pull those to the top level array of the swagger definition', () => {
+      const Dog = mongoose.model('Dog', {
+        name: {
+          type: String,
+          required: true
+        },
+        likesWater: {
+          type: Boolean,
+          required: true
+        },
+        isGoodBoy: {
+          type: Boolean
+        }
+      });
+      const swaggerSchema = m2s(Dog);
+      expect(swaggerSchema.id).toBe('Dog');
+      expect(swaggerSchema.required).toEqual(['name', 'likesWater']);
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,6 @@ describe('mongoose-to-swagger', function () {
     it('should do something', () => {
       const Cat = mongoose.model('Cat', {name: String});
       const swaggerSchema = m2s(Cat);
-      expect(swaggerSchema.id).toBe('Cat');
       expect(swaggerSchema.properties).toExist();
     });
   });
@@ -35,7 +34,6 @@ describe('mongoose-to-swagger', function () {
         }
       });
       const swaggerSchema = m2s(Dog);
-      expect(swaggerSchema.id).toBe('Dog');
       expect(swaggerSchema.required).toEqual(['name', 'likesWater']);
     });
   });


### PR DESCRIPTION
This PR changes how `required` properties get put onto definitions. Instead of being on each property, which seems to throw an error with Swagger 2.0, it will now get pulled to the top of the definition object in an array.

Another fix changes the `id` to `title`, which was throwing an error, too.

Support for swagger `enum` is added, also.