### PR TITLE
Mongo and Mongoose do not have separate Date and DateTime

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ function documentModel(Model) {
         modelProp.required = mongooseProp.isRequired || false;
       } else if (mongooseProp.instance === 'Date') {
         modelProp.type = 'string';
-        modelProp.format = 'date';
+        modelProp.format = 'datetime';
         modelProp.required = mongooseProp.isRequired || false;
       } else {
         modelProp.type = adjustType(mongooseProp.instance);

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -66,7 +66,7 @@ describe(path.basename(__filename).replace('.test.js', ''), () => {
       const props = result.properties;
       expect(props.date).toExist();
       expect(props.date.type).toBe('string');
-      expect(props.date.format).toBe('date');
+      expect(props.date.format).toBe('datetime');
     });
     it('mongoose model relation', () => {
       const result = documentModel({schema});


### PR DESCRIPTION
MongoDB and Mongoose use the JavaScript Date object, which is really a date and time. Swagger has two string formats, `date` and `datetime`. This PR changes the outputted format for a Mongoose Date to `datetime`.

This should have backward compatibility - something like `2018-05-24` that was sent through swagger would have come back from Mongo as `2018-05-24T00:00:00.000Z` anyways, and to re-update the field, you had to drop everything from the `T` onward.