### PR TITLE
Add support for Mongoose Map type

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -147,6 +147,10 @@ describe('index.test.ts', () => {
         likes: [],
         date: { type: Date, default: Date.now },
         hidden: { type: Boolean, required: true },
+        toggles: {
+          type: Map,
+          of: Boolean,
+        },
         meta: {
           votes: Number,
           favs: Number,
@@ -366,6 +370,16 @@ describe('index.test.ts', () => {
       expect(props.date).to.exist;
       expect(props.date.type).to.equal('string');
       expect(props.date.format).to.equal('date-time');
+    });
+
+    it('map', () => {
+      const result = documentModel({ schema });
+      const props = result.properties;
+      expect(props.toggles).to.exist;
+      expect(props.toggles.type).to.equal('object');
+      const additionalProperties = props.toggles.additionalProperties;
+      expect(additionalProperties).to.exist;
+      expect(additionalProperties.type).to.equal('boolean');
     });
 
     it('mongoose model relation', () => {


### PR DESCRIPTION
This adds support for Mongoose's Map schema type (added in 5.1.0):
https://mongoosejs.com/docs/schematypes.html#maps

I followed Swagger's map/dictionary schema:
https://swagger.io/specification/#model-with-mapdictionary-properties

I added one unit test, but I've been testing this with schemas in my personal project and it seems to work as expected. Let me know if you want me to add more tests.
