### PR TITLE
Fix "id" not being saved if it is in props

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -183,7 +183,7 @@ const getFieldsFromMongooseSchema = (schema: {
   // loop over the tree of mongoose schema types
   // and return an array of swagger fields
   for (const key of keys
-    .filter(x => x != 'id')
+    .filter(x => x != 'id' || props.includes("id"))
   ) {
     const value = tree[key];
 


### PR DESCRIPTION
ID is not being saved if it is in props

```ts
mongooseToSwagger(Model, {
	props: ["id"]
})
// result will not have "id" prop
```