### PR TITLE
Delete empty required array

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -215,6 +215,9 @@ const getFieldsFromMongooseSchema = (schema: {
           delete val.required;
         }
       }
+      if (!field.items.required.length) {
+        delete field.items.required;
+      }
     }
 
     fields.push(field);


### PR DESCRIPTION
Delete empty required array to avoid swagger validation errors:

Structural error at components.schemas.[schema-name].properties.containers.items.required should NOT have fewer than 1 items
limit: 1