### PR TITLE
Allow required, description, and enum to be regular fields if their types are wrong

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -126,7 +126,7 @@ const mapSchemaTypeToFieldSchema = ({
     const metaValue = value[metaProp];
     const isValidEnum = metaValue === 'enum' ? Array.isArray(metaValue) : true;
     const isValidRequired = metaValue === 'required' ? Array.isArray(metaValue) || typeof metaValue === 'boolean' : true;
-    const isValidDescription = metaValue === 'enum' ? typeof metaValue === 'string' : true;
+    const isValidDescription = metaValue === 'description' ? typeof metaValue === 'string' : true;
     const defaultSupportedMetaPropsAreValid = isValidDescription && isValidEnum && isValidRequired;
     if (value && metaValue != null && defaultSupportedMetaPropsAreValid) {
       meta[metaProp] = metaValue;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -123,7 +123,13 @@ const mapSchemaTypeToFieldSchema = ({
   const meta: any = {};
 
   for (const metaProp of props) {
-    if (value && value[metaProp] != null) {
+    const isValidEnum = metaProp === 'enum' ? Array.isArray(metaProp) : true;
+    const isValidRequired = metaProp === 'required'
+      ? Array.isArray(metaProp) || typeof metaProp === 'boolean'
+      : true;
+    const isValidDescription = metaProp === 'enum' ? typeof metaProp === 'string' : true;
+    const defaultSupportedMetaPropsAreValid = isValidDescription && isValidEnum && isValidRequired;
+    if (value && value[metaProp] != null && defaultSupportedMetaPropsAreValid) {
       meta[metaProp] = value[metaProp];
     }
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -123,14 +123,13 @@ const mapSchemaTypeToFieldSchema = ({
   const meta: any = {};
 
   for (const metaProp of props) {
-    const isValidEnum = metaProp === 'enum' ? Array.isArray(metaProp) : true;
-    const isValidRequired = metaProp === 'required'
-      ? Array.isArray(metaProp) || typeof metaProp === 'boolean'
-      : true;
-    const isValidDescription = metaProp === 'enum' ? typeof metaProp === 'string' : true;
+    const metaValue = value[metaProp];
+    const isValidEnum = metaValue === 'enum' ? Array.isArray(metaValue) : true;
+    const isValidRequired = metaValue === 'required' ? Array.isArray(metaValue) || typeof metaValue === 'boolean' : true;
+    const isValidDescription = metaValue === 'enum' ? typeof metaValue === 'string' : true;
     const defaultSupportedMetaPropsAreValid = isValidDescription && isValidEnum && isValidRequired;
-    if (value && value[metaProp] != null && defaultSupportedMetaPropsAreValid) {
-      meta[metaProp] = value[metaProp];
+    if (value && metaValue != null && defaultSupportedMetaPropsAreValid) {
+      meta[metaProp] = metaValue;
     }
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -124,9 +124,9 @@ const mapSchemaTypeToFieldSchema = ({
 
   for (const metaProp of props) {
     const metaValue = value[metaProp];
-    const isValidEnum = metaValue === 'enum' ? Array.isArray(metaValue) : true;
-    const isValidRequired = metaValue === 'required' ? Array.isArray(metaValue) || typeof metaValue === 'boolean' : true;
-    const isValidDescription = metaValue === 'description' ? typeof metaValue === 'string' : true;
+    const isValidEnum = metaProps === 'enum' ? Array.isArray(metaValue) : true;
+    const isValidRequired = metaProps === 'required' ? Array.isArray(metaValue) || typeof metaValue === 'boolean' : true;
+    const isValidDescription = metaProps === 'description' ? typeof metaValue === 'string' : true;
     const defaultSupportedMetaPropsAreValid = isValidDescription && isValidEnum && isValidRequired;
     if (value && metaValue != null && defaultSupportedMetaPropsAreValid) {
       meta[metaProp] = metaValue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-to-swagger",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-to-swagger",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Conversion library for transforming Mongoose schema objects into Swagger schema definitions.",
   "homepage": "",
   "author": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "test:watch": "mocha lib/*.test.js --watch",
     "test": "mocha lib/*.test.ts",
     "build": "tsc",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "preinstall": "npm run build"
   },
   "dependencies": {},
   "license": "MIT",


### PR DESCRIPTION
Would you accept this PR if I added some tests and removed the preinstall step?

The idea here is to not set the meta fields unless they're of a type that it's expecting, effectively allowing mongoose fields called `required`, `description` (quite common), or `enum`.

I'm not 100% sure this is the best way to do it, but it works 🤷 

This would fix this issue: https://github.com/giddyinc/mongoose-to-swagger/issues/36