### PR TITLE
handle schema with array property set to SchemaType instance

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -131,7 +131,7 @@ const mapSchemaTypeToFieldSchema = ({
   if (value === Date || value.type === Date) {
     meta.format = 'date-time';
   } else if (swaggerType === 'array') {
-    const arraySchema = Array.isArray(value) ? value[0] : value.type[0];
+    const arraySchema = Array.isArray(value) ? value[0] : value.$isMongooseArray ? value.$embeddedSchemaType.instance : value.type[0];
     const items = mapSchemaTypeToFieldSchema({ value: arraySchema || {}, props, omitFields });
     meta.items = items;
   } else if (swaggerType === 'object') {


### PR DESCRIPTION
Currently running mongoose-to-swagger on a schema with arrays that are `pick()`-ed from another schema throws the following error:

```
/node_modules/mongoose-to-swagger/dist/index.js:100
        const arraySchema = Array.isArray(value) ? value[0] : value.type[0];
                                                                        ^

TypeError: Cannot read properties of undefined (reading '0')
    at mapSchemaTypeToFieldSchema (/home/val/Workspace/voltmobile/core-api/node_modules/mongoose-to-swagger/dist/index.js:100:73)

```
